### PR TITLE
Remove pdfium runtimes and reference NuGet package

### DIFF
--- a/src/PDFiumCore/PDFiumCore.csproj
+++ b/src/PDFiumCore/PDFiumCore.csproj
@@ -19,10 +19,10 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="runtimes/**" PackagePath="runtimes" />
+    <PackageReference Include="bblanchon.PDFium.Linux" Version="$(Version)" PrivateAssets="analyzers" />
+    <PackageReference Include="bblanchon.PDFium.macOS" Version="$(Version)" PrivateAssets="analyzers" />
+    <PackageReference Include="bblanchon.PDFium.Win32" Version="$(Version)" PrivateAssets="analyzers" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\CppSharp\src\Runtime\MarshalUtil.cs" Link="CppSharp\MarshalUtil.cs" />


### PR DESCRIPTION
[See issue from the pdfium-binaries repository for context.](https://github.com/bblanchon/pdfium-binaries/issues/77)

- PDFiumCore references @bblanchon's NuGet packages:
  - [bblanchon.PDFium.Linux](https://www.nuget.org/packages/bblanchon.PDFium.Linux/)
  - [bblanchon.PDFium.macOS](https://www.nuget.org/packages/bblanchon.PDFium.macOS/)
  - [bblanchon.PDFium.Win32](https://www.nuget.org/packages/bblanchon.PDFium.Win32/)
- The native pdfium libs **pdfium-win-x86**, **pdfium-win-x64**, **pdfium-linux-x64** and **pdfium-mac-x64** are no longer packaged directly.
- CppSharp generates the bindings with the header files from **pdfium-win-x64** (no changes here).