### PR TITLE
Zero initialize FPDF_FORMFILLINFO struct

### DIFF
--- a/src/PDFiumCoreBindingsGenerator/PDFiumCoreLibrary.cs
+++ b/src/PDFiumCoreBindingsGenerator/PDFiumCoreLibrary.cs
@@ -41,6 +41,10 @@ namespace PDFiumCoreBindingsGenerator
             options.CommentKind = CommentKind.BCPLSlash;
             options.OutputDir = _directoryName;
 
+            driver.Options.ZeroAllocatedMemory = cls => {
+                return cls.QualifiedName == "FPDF_FORMFILLINFO";
+            };
+
             var module = options.AddModule("PDFiumCore");
             module.SharedLibraryName = "pdfium";
 


### PR DESCRIPTION
Some of the structs used in the C++ library are expected to be initialized to zero, because in C++ you are expected to initialize it on the stack:

```cpp
FPDF_FORMFILLINFO info = {0};
```

PDFiumCore currently does not configure this for any struct, which results in garbage data being read in certain cases. I am not sure what all the structs are that need to be zero'd, so this PR simply zeroes the one struct I know for sure has to be zero'd or it causes problems: `FPDF_FORMFILLINFO`.